### PR TITLE
MAINT: Set up ES2017 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "@google/clasp": "^1.3.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
-    "babel-plugin-transform-es2017-object-entries": "^0.0.4",
-    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-google-apps-script": "^0.0.3",
     "copy-webpack-plugin": "^4.5.1",
@@ -27,5 +25,8 @@
     "gas-webpack-plugin": "^0.3.0",
     "webpack": "^4.8.3",
     "webpack-cli": "^2.1.4"
+  },
+  "dependencies": {
+    "babel-polyfill": "^6.26.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,9 @@
+// Need to import `babel-polyfill` here, instead of in the webpack entry config,
+// not sure why, but GAS complains about function registrations otherwise,
+// so this seems like an easy compromise.
+
+import 'babel-polyfill';
+
 // This file is the entry point for webpack. Import all modules here to ensure
 // all side effects are run. Individual modules perform their own global context
 // registration.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,13 @@ const GasPlugin = require('gas-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
+  // No need to minify - this runs on the GAS platform, we aren't concerned
+  // about making this bundle efficient for network transfers. As well,
+  // this makes debugging on script.google.com slightly easier.
   mode: 'none',
+  // Cannot load `babel-polyfill` here, as suggested in the docs, otherwise
+  // GAS complains about how it is registered in the global context. The easiest
+  // workaround appears to be to just `import` the library within `main.js`.
   entry: './src/main.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -22,18 +28,30 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        // `regenerator-runtime` needs to be transpiled so that the rhino
+        // runtime on GAS doesn't complain. If other deps need this treatment
+        // in the future, simply add to the list: (foo|bar|baz).
+        exclude: /node_modules\/(?!(regenerator-runtime)\/).*/,
         use: [
           {
             loader: 'babel-loader',
             options: {
               presets: [
-                'babel-preset-env',
-                'google-apps-script',
+                [
+                  'babel-preset-env',
+                  {
+                    // GAS complains about how the polyfill is registered when
+                    // this is false. Again, not sure why this is the case, but
+                    // setting this to `true` appears to alleviate the pain.
+                    useBuiltIns: true,
+                  },
+                ],
+                [
+                  'google-apps-script',
+                ],
               ],
               plugins: [
-                'transform-object-assign',
-                'transform-es2017-object-entries'
+                // Add any plugins needed here.
               ],
             }
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,30 +596,6 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.20.0, babel-core@^6.26.3:
-  version "6.26.3"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.1"
-    debug "^2.6.9"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.8"
-    slash "^1.0.0"
-    source-map "^0.5.7"
-
 babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
@@ -643,6 +619,30 @@ babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
 
 babel-generator@^6.26.0:
   version "6.26.1"
@@ -1050,12 +1050,6 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es20
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
-babel-plugin-transform-es2017-object-entries@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2017-object-entries/-/babel-plugin-transform-es2017-object-entries-0.0.4.tgz#c5ca37c44d06fef63520e3057899fd4ca185b200"
-  dependencies:
-    babel-core "^6.20.0"
-
 babel-plugin-transform-es3-member-expression-literals@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz#733d3444f3ecc41bef8ed1a6a4e09657b8969ebb"
@@ -1090,12 +1084,6 @@ babel-plugin-transform-flow-strip-types@^6.8.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-assign@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-object-rest-spread@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
@@ -1115,6 +1103,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
+
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
 
 babel-preset-env@^1.7.0:
   version "1.7.0"
@@ -5373,6 +5369,10 @@ recursive-readdir@^2.2.1:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Dropped ad-hoc plugins `babel-plugin-transform-es2017-object-entries` & `babel-plugin-transform-object-assign` in favor of `babel-polyfill`, which should get us es2015, es2016, and es2017 language features (via `babel-preset-env`).

Note, I tested this by running some dummy functions that utilize modern es201* features (like `Object.assign`, `Object.values`, and `Array.includes`)